### PR TITLE
Update JobManagement server URL

### DIFF
--- a/azure-ai-foundry/openapi-specs/JobManagement.json
+++ b/azure-ai-foundry/openapi-specs/JobManagement.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3000",
+      "url": "https://video-transcribe-api.calmocean-ce622c12.eastus2.azurecontainerapps.io",
       "description": "Local development server"
     }
   ],


### PR DESCRIPTION
## Summary
- update JobManagement OpenAPI spec to point to the production API host

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfa72e582c83288085568bbd9d277d