### PR TITLE
Align JobManagement server config with production

### DIFF
--- a/azure-ai-foundry/openapi-specs/JobManagement.json
+++ b/azure-ai-foundry/openapi-specs/JobManagement.json
@@ -7,8 +7,8 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3000",
-      "description": "Local development server"
+      "url": "https://video-transcribe-api.calmocean-ce622c12.eastus2.azurecontainerapps.io",
+      "description": "Production API server"
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary
- update the JobManagement OpenAPI spec to use the production server URL and description

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfa9b911f483289c21ee1677c1097b